### PR TITLE
Populate /etc/yum/vars/releasever on CentOS

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,13 @@
           - "{{ convert2rhel_package_url }}"
         state: present
 
+    - name: Add 7Server to file /etc/yum/vars/releasever if it does not exist on CentOS systems
+      lineinfile:
+        path: /etc/yum/vars/releasever
+        line: 7Server
+        create: yes
+      when: ansible_distribution == 'CentOS'
+
     - block:
         - name: Install required packages on Oracle
           yum:


### PR DESCRIPTION
On CentOS systems, convert2rhel errors out:

"https://cdn.redhat.com/content/dist/rhel/server/7/%24releasever/x86_64/optional/os/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found",

This is rectified by creating the file /etc/yum/vars/releasever with content "7Server" prior to executing convert2rhel:

# python -c 'import yum, pprint; yb = yum.YumBase(); pprint.pprint(yb.conf.yumvar, width=1)'
Loaded plugins: fastestmirror, product-id, subscription-manager
{'arch': 'ia32e',
 'basearch': 'x86_64',
 'contentdir': 'centos',
 'releasever': '$releasever',
 'uuid': '14468f3d-d9e1-4ae7-95db-98b06f64ad88'}

# echo "7Server" > /etc/yum/vars/releasever

# python -c 'import yum, pprint; yb = yum.YumBase(); pprint.pprint(yb.conf.yumvar, width=1)'
Loaded plugins: fastestmirror, product-id, subscription-manager
{'arch': 'ia32e',
 'basearch': 'x86_64',
 'contentdir': 'centos',
 'releasever': '7Server',
 'uuid': '14468f3d-d9e1-4ae7-95db-98b06f64ad88'}